### PR TITLE
#57 especificação de bot-merge para 2 aprovadores

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,6 +1,6 @@
 
 minApprovals:
-  MEMBER: 3
+  MEMBER: 2
   COLLABORATOR: 1
 
 maxRequestedChanges:


### PR DESCRIPTION
Pois os apenas o professor é um colaborador e como alunos somos membros e pela quantidade de pessoas 2 codereviews são suficientes